### PR TITLE
Rename project from weather-cli to rancast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ From this point forward, development should follow a pull request-based workflow
 ## Project Structure
 
 - `main.go` - Main application with CLI interface
-- `weather-cli` - Compiled binary
+- `rancast` - Compiled binary
 - `go.mod` - Go module definition
 - `README.md` - User documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Running Weather CLI
+# Rancast
 
-Go言語で作られた**ランニング特化**の天気予報CLIツールです。
+Go言語で作られた**ランニング特化**の天気予報CLIツール「**Rancast**（ランキャスト）」です。
 
 ## 機能
 
@@ -16,32 +16,32 @@ Go言語で作られた**ランニング特化**の天気予報CLIツールで�
 ### インストール
 
 ```bash
-go build -o weather-cli
+go build -o rancast
 ```
 
 ### 基本的な使用方法
 
 ```bash
 # 🏃‍♂️ 東京の現在のランニング情報を取得
-./weather-cli -city tokyo
+./rancast -city tokyo
 
 # ⏰ 東京の早朝時間帯のランニング情報を取得
-./weather-cli -city tokyo -time morning
+./rancast -city tokyo -time morning
 
 # 📅 明日の東京のランニング情報を取得
-./weather-cli -city tokyo -date tomorrow
+./rancast -city tokyo -date tomorrow
 
 # 📅 明後日の札幌の早朝ランニング情報を取得
-./weather-cli -city sapporo -date day-after-tomorrow -time morning
+./rancast -city sapporo -date day-after-tomorrow -time morning
 
 # 🏃‍♂️ 距離別推奨: フルマラソン用の天気評価
-./weather-cli -city tokyo -distance full
+./rancast -city tokyo -distance full
 
 # 🏃‍♂️ 距離別推奨: 10km用の明日の天気評価
-./weather-cli -city osaka -distance 10k -date tomorrow
+./rancast -city osaka -distance 10k -date tomorrow
 
 # ⏰ 大阪の夕方時間帯のハーフマラソン用情報
-./weather-cli -city osaka -time evening -distance half
+./rancast -city osaka -time evening -distance half
 ```
 
 ### オプション

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module weather-cli
+module rancast
 
 go 1.24.4

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"testing"
-	"weather-cli/internal/weather"
+	"rancast/internal/weather"
 )
 
 // Integration tests for API calls

--- a/internal/display/date.go
+++ b/internal/display/date.go
@@ -2,9 +2,9 @@ package display
 
 import (
 	"fmt"
-	"weather-cli/internal/running"
-	"weather-cli/internal/types"
-	"weather-cli/internal/weather"
+	"rancast/internal/running"
+	"rancast/internal/types"
+	"rancast/internal/weather"
 )
 
 // DisplayTimeBasedWeather displays time-based weather information

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -2,9 +2,9 @@ package display
 
 import (
 	"fmt"
-	"weather-cli/internal/running"
-	"weather-cli/internal/types"
-	"weather-cli/internal/weather"
+	"rancast/internal/running"
+	"rancast/internal/types"
+	"rancast/internal/weather"
 )
 
 // GetRunningTempIcon returns temperature icon for running

--- a/internal/display/running.go
+++ b/internal/display/running.go
@@ -2,9 +2,9 @@ package display
 
 import (
 	"fmt"
-	"weather-cli/internal/running"
-	"weather-cli/internal/types"
-	"weather-cli/internal/weather"
+	"rancast/internal/running"
+	"rancast/internal/types"
+	"rancast/internal/weather"
 )
 
 // DisplayRunningForecastWithDistance displays running forecast with distance consideration

--- a/internal/running/running.go
+++ b/internal/running/running.go
@@ -1,7 +1,7 @@
 package running
 
 import (
-	"weather-cli/internal/types"
+	"rancast/internal/types"
 )
 
 // DistanceCategory is an alias for types.DistanceCategory for backward compatibility

--- a/internal/weather/time.go
+++ b/internal/weather/time.go
@@ -1,7 +1,7 @@
 package weather
 
 import (
-	"weather-cli/internal/types"
+	"rancast/internal/types"
 )
 
 // GetTimePeriods returns all available time periods

--- a/internal/weather/time_test.go
+++ b/internal/weather/time_test.go
@@ -2,7 +2,7 @@ package weather
 
 import (
 	"testing"
-	"weather-cli/internal/types"
+	"rancast/internal/types"
 )
 
 func TestGetTimePeriods(t *testing.T) {

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-	"weather-cli/internal/types"
+	"rancast/internal/types"
 )
 
 const apiURL = "https://api.open-meteo.com/v1/jma"

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
-	"weather-cli/internal/display"
-	"weather-cli/internal/running"
-	"weather-cli/internal/types"
-	"weather-cli/internal/weather"
+	"rancast/internal/display"
+	"rancast/internal/running"
+	"rancast/internal/types"
+	"rancast/internal/weather"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
• Rename the project from `weather-cli` to `rancast` (ランキャスト) to better reflect its running-specialized purpose
• Update all module names, import paths, and documentation to use the new name
• Maintain 100% backward compatibility of all functionality

## Changes Made
- **Go Module**: Updated module name from `weather-cli` to `rancast`
- **Binary Name**: Changed compiled binary from `weather-cli` to `rancast`
- **Import Paths**: Updated all internal package imports to use `rancast/internal/*`
- **Documentation**: Updated README.md with new name and command examples
- **Project Files**: Updated CLAUDE.md and other project references

## Rationale
The new name `rancast` (running + forecast) better communicates the tool's specialized purpose:
- More memorable and brandable than `weather-cli`
- Clearly indicates running focus rather than general weather
- Shorter and easier to type for frequent CLI usage
- Follows CLI tool naming conventions

## Test plan
- [x] All unit tests pass
- [x] Application builds successfully as `rancast`
- [x] All functionality works identically to previous version
- [x] Help output shows correct binary name
- [x] All internal imports resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)