### PR TITLE
-dateオプションと-timeオプション使用時に風速情報を表示

### DIFF
--- a/internal/display/date.go
+++ b/internal/display/date.go
@@ -129,6 +129,7 @@ func DisplayDateBasedRunningWeatherWithDistanceAndDust(weatherData *types.Weathe
 
 	fmt.Printf("🌡️ %s%.1f°C〜%.1f°C\n", GetRunningTempIcon(avgTemp), minTemp, maxTemp)
 	fmt.Printf("☁️ %s\n", weather.GetWeatherDescription(weatherCode))
+	fmt.Printf("🌬️ 最大風速: %.1f m/s\n", maxWind)
 	if precipitation > 0 {
 		fmt.Printf("🌧️ 降水量: %.1f mm\n", precipitation)
 	}
@@ -269,8 +270,8 @@ func DisplayDateTimeBasedRunningWeatherWithDistanceAndDust(weatherData *types.We
 		running.ApplyDustPenalty(&condition, dustLevel, distanceCategory)
 
 		fmt.Printf("🕐 %s時: %d/100 (%s)\n", hour, condition.Score, condition.Level)
-		fmt.Printf("   🌡️ %.1f°C (体感: %.1f°C) | 💧 %d%%\n",
-			data.Temperature, data.ApparentTemp, data.Humidity)
+		fmt.Printf("   🌡️ %.1f°C (体感: %.1f°C) | 💧 %d%% | 🌬️ %s %.1fm/s\n",
+			data.Temperature, data.ApparentTemp, data.Humidity, weather.GetWindDirection(data.WindDirection), data.WindSpeed)
 		fmt.Printf("   ☁️ %s", weather.GetWeatherDescription(data.WeatherCode))
 		if data.Precipitation > 0 {
 			fmt.Printf(" | 🌧️ %.1fmm", data.Precipitation)

--- a/internal/display/running.go
+++ b/internal/display/running.go
@@ -77,8 +77,8 @@ func DisplayTimeBasedRunningWeatherWithDistanceAndDust(weatherData *types.Weathe
 		running.ApplyDustPenalty(&condition, dustLevel, distanceCategory)
 
 		fmt.Printf("🕐 %s時: %d/100 (%s)\n", hour, condition.Score, condition.Level)
-		fmt.Printf("   🌡️ %.1f°C (体感: %.1f°C) | 💧 %d%%\n",
-			data.Temperature, data.ApparentTemp, data.Humidity)
+		fmt.Printf("   🌡️ %.1f°C (体感: %.1f°C) | 💧 %d%% | 🌬️ %s %.1fm/s\n",
+			data.Temperature, data.ApparentTemp, data.Humidity, weather.GetWindDirection(data.WindDirection), data.WindSpeed)
 		fmt.Printf("   ☁️ %s", weather.GetWeatherDescription(data.WeatherCode))
 		if data.Precipitation > 0 {
 			fmt.Printf(" | 🌧️ %.1fmm", data.Precipitation)


### PR DESCRIPTION
## Summary

- `-time`オプション使用時に各時間の風向・風速を表示するように修正
- `-date`オプション使用時に最大風速を表示するように修正
- `-date -time`オプション併用時にも風向・風速を表示

## 変更内容

### Before
```
🕐 06時: 70/100 (良好)
   🌡️ -0.8°C (体感: -4.9°C) | 💧 55%
   ☁️ 快晴
```

### After
```
🕐 06時: 70/100 (良好)
   🌡️ -0.8°C (体感: -4.9°C) | 💧 55% | 🌬️ 北北西 6.6m/s
   ☁️ 快晴
```

日付別表示にも最大風速を追加:
```
🌬️ 最大風速: 9.4 m/s
```

## Test plan
- [x] `go test -short ./...` で全テスト通過
- [x] `-time morning` で風速表示を確認
- [x] `-date tomorrow` で最大風速表示を確認
- [x] `-date tomorrow -time morning` で風速表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)